### PR TITLE
Literal Type evaluation and Specs

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -20,33 +20,32 @@ define([
         this._ast = jsep(expression);
         this._runtimeAST = undefined;
 
-        // create "compiled" AST
-        createRuntimeAst(this);
+        console.log(this._ast);
+        this._runtimeAST = createRuntimeAst(this._ast);
+        console.log(this._runtimeAST);
     }
 
-    function createRuntimeAst(expression) {
-        console.log(expression._ast);
-        if (expression._ast.type === 'Literal') {
-            expression._runtimeAST = expression._ast;
-
-            var value = expression._ast.value;
+    function createRuntimeAst(ast) {
+        var node = ast;
+        if (ast.type === 'Literal') {
 
             //check if the string is a color, if so turn it into a cesium color
-            if (typeof(value) === 'string') {
-                var c = Color.fromCssColorString(value);
+            if (typeof(ast.value) === 'string') {
+                var c = Color.fromCssColorString(ast.value);
                 if (defined(c)) {
-                    expression._runtimeAST.value = c;
+                    node.value = c;
                 }
             }
         }
-        console.log(expression._runtimeAST);
+
+        return node;
     }
 
     defineProperties(Expression.prototype, {
     });
 
     Expression.prototype.evaluate = function(feature) {
-        // if it's a literal, we're done, return value
+
         if (this._runtimeAST.type === 'Literal') {
             return this._runtimeAST.value;
         }

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -1,8 +1,12 @@
 /*global define*/
 define([
+       '../Core/Color',
+       '../Core/defined',
        '../Core/defineProperties',
-       '../ThirdParty/jsep',
+       '../ThirdParty/jsep'
     ], function(
+        Color,
+        defined,
         defineProperties,
         jsep) {
     "use strict";
@@ -13,14 +17,41 @@ define([
     function Expression(styleEngine, expression) {
         this._styleEngine = styleEngine;
 
-        console.log(jsep(expression));
+        this._ast = jsep(expression);
+        this._runtimeAST = undefined;
+
+        // create "compiled" AST
+        createRuntimeAst(this);
+    }
+
+    function createRuntimeAst(expression) {
+        console.log(expression._ast);
+        if (expression._ast.type === 'Literal') {
+            expression._runtimeAST = expression._ast;
+
+            var value = expression._ast.value;
+
+            //check if the string is a color, if so turn it into a cesium color
+            if (typeof(value) === 'string') {
+                var c = Color.fromCssColorString(value);
+                if (defined(c)) {
+                    expression._runtimeAST.value = c;
+                }
+            }
+        }
+        console.log(expression._runtimeAST);
     }
 
     defineProperties(Expression.prototype, {
     });
 
     Expression.prototype.evaluate = function(feature) {
-        return true;
+        // if it's a literal, we're done, return value
+        if (this._runtimeAST.type === 'Literal') {
+            return this._runtimeAST.value;
+        }
+
+        return undefined;
     };
 
     return Expression;

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -13,6 +13,11 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
+    it('evaluates literal null', function() {
+        var expression = new Expression(new MockStyleEngine(), 'null');
+        expect(expression.evaluate(undefined)).toEqual(null);
+    });
+
     it('evaluates literal boolean', function() {
         var expression = new Expression(new MockStyleEngine(), 'true');
         expect(expression.evaluate(undefined)).toEqual(true);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -40,10 +40,13 @@ defineSuite([
     });
 
     it('evaluates literal color', function() {
-        var expression = new Expression(new MockStyleEngine(), '\'#ffffff\'');
+        var expression = new Expression(new MockStyleEngine(), 'color(\'#ffffff\')');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), '\'white\'');
+        expression = new Expression(new MockStyleEngine(), 'color(\'white\')');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'rgb(255, 255, 255)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
     });
 });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1,8 +1,10 @@
 /*global defineSuite*/
 defineSuite([
-        'Scene/Expression'
+        'Scene/Expression',
+        'Core/Color'
     ], function(
-        Expression) {
+        Expression,
+        Color) {
     'use strict';
 
     function MockStyleEngine() {
@@ -11,8 +13,32 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
-    it('evalutes', function() {
+    it('evaluates literal boolean', function() {
         var expression = new Expression(new MockStyleEngine(), 'true');
         expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'false');
+        expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
+    it('evaluates literal number', function() {
+        var expression = new Expression(new MockStyleEngine(), '1');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), '0');
+        expect(expression.evaluate(undefined)).toEqual(0);
+    });
+
+    it('evaluates literal string', function() {
+        var expression = new Expression(new MockStyleEngine(), '\'hello\'');
+        expect(expression.evaluate(undefined)).toEqual('hello');
+    });
+
+    it('evaluates literal color', function() {
+        var expression = new Expression(new MockStyleEngine(), '\'#ffffff\'');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), '\'white\'');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
     });
 });


### PR DESCRIPTION
Simply check for literal type and evaluate to the literal's value.

I added specs to check for evaluation of literal:
  * null
  * boolean
  * number
  * string
  * Color

For color, I check if the literal is a string, and if its a valid css color, then 'compile' it to the Cesium `Color`. Something to think about is how to determine a literal string that happens to be a color from a string that is supposed to be a color? (I just want to say 'green'). 

@pjcozzi 
