### PR TITLE
Evaluate Operators if possible when constructing AST

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -20,33 +20,32 @@ define([
         this._ast = jsep(expression);
         this._runtimeAST = undefined;
 
-        // create "compiled" AST
-        createRuntimeAst(this);
+        console.log(this._ast);
+        this._runtimeAST = createRuntimeAst(this._ast);
+        console.log(this._runtimeAST);
     }
 
-    function createRuntimeAst(expression) {
-        console.log(expression._ast);
-        if (expression._ast.type === 'Literal') {
-            expression._runtimeAST = expression._ast;
-
-            var value = expression._ast.value;
+    function createRuntimeAst(ast) {
+        var node = ast;
+        if (ast.type === 'Literal') {
 
             //check if the string is a color, if so turn it into a cesium color
-            if (typeof(value) === 'string') {
-                var c = Color.fromCssColorString(value);
+            if (typeof(ast.value) === 'string') {
+                var c = Color.fromCssColorString(ast.value);
                 if (defined(c)) {
-                    expression._runtimeAST.value = c;
+                    node.value = c;
                 }
             }
         }
-        console.log(expression._runtimeAST);
+
+        return node;
     }
 
     defineProperties(Expression.prototype, {
     });
 
     Expression.prototype.evaluate = function(feature) {
-        // if it's a literal, we're done, return value
+
         if (this._runtimeAST.type === 'Literal') {
             return this._runtimeAST.value;
         }

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -1,8 +1,12 @@
 /*global define*/
 define([
+       '../Core/Color',
+       '../Core/defined',
        '../Core/defineProperties',
-       '../ThirdParty/jsep',
+       '../ThirdParty/jsep'
     ], function(
+        Color,
+        defined,
         defineProperties,
         jsep) {
     "use strict";
@@ -13,14 +17,41 @@ define([
     function Expression(styleEngine, expression) {
         this._styleEngine = styleEngine;
 
-        console.log(jsep(expression));
+        this._ast = jsep(expression);
+        this._runtimeAST = undefined;
+
+        // create "compiled" AST
+        createRuntimeAst(this);
+    }
+
+    function createRuntimeAst(expression) {
+        console.log(expression._ast);
+        if (expression._ast.type === 'Literal') {
+            expression._runtimeAST = expression._ast;
+
+            var value = expression._ast.value;
+
+            //check if the string is a color, if so turn it into a cesium color
+            if (typeof(value) === 'string') {
+                var c = Color.fromCssColorString(value);
+                if (defined(c)) {
+                    expression._runtimeAST.value = c;
+                }
+            }
+        }
+        console.log(expression._runtimeAST);
     }
 
     defineProperties(Expression.prototype, {
     });
 
     Expression.prototype.evaluate = function(feature) {
-        return true;
+        // if it's a literal, we're done, return value
+        if (this._runtimeAST.type === 'Literal') {
+            return this._runtimeAST.value;
+        }
+
+        return undefined;
     };
 
     return Expression;

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -27,15 +27,38 @@ define([
 
     function createRuntimeAst(ast) {
         var node = ast;
-        if (ast.type === 'Literal') {
 
-            //check if the string is a color, if so turn it into a cesium color
+        // evaluate this node if we can
+        if (ast.type === 'Literal') {
             if (typeof(ast.value) === 'string') {
                 var c = Color.fromCssColorString(ast.value);
                 if (defined(c)) {
                     node.value = c;
                 }
             }
+        } else if(ast.type === 'UnaryExpression') {
+            var operand = createRuntimeAst(ast.argument);
+            if (operand.type === 'Literal') {
+                node = defineLiteralNode(evaluateUnary(ast.operator, operand.value));
+            }
+        } else if (ast.type === 'BinaryExpression') {
+            var left = createRuntimeAst(ast.left);
+            var right = createRuntimeAst(ast.right);
+            if (left.type === 'Literal' && right.type === 'Literal') {
+                node = defineLiteralNode(evaluateBinary(left.value, ast.operator, right.value));
+            }
+        } else if (ast.type === 'LogicalExpression') {
+            var l = createRuntimeAst(ast.left);
+            var r = createRuntimeAst(ast.right);
+            if (l.type === 'Literal' && r.type === 'Literal') {
+                node = defineLiteralNode(evaluateLogical(l.value, ast.operator, r.value));
+            }
+        } else if (ast.type === 'ConditionalExpression') {
+            var test = createRuntimeAst(ast.test);
+            if (test.type === 'Literal') {
+                node = createRuntimeAst(evaluateConditional(test.value, ast.consequent, ast.alternate));
+            }
+
         }
 
         return node;
@@ -44,9 +67,74 @@ define([
     defineProperties(Expression.prototype, {
     });
 
-    Expression.prototype.evaluate = function(feature) {
+    function defineLiteralNode(value) {
+        return {
+            'type' : 'Literal',
+            'value' : value,
+            'raw' : value
+        };
+    }
 
-        if (this._runtimeAST.type === 'Literal') {
+    function evaluateUnary(operator, operand) {
+        if (operator === '!') {
+            if (typeof(operand) === 'boolean') {
+                return !operand;
+            }
+        } else if (operator === '-') {
+            if (typeof(operand) === 'number') {
+                return -operand;
+            }
+        }
+
+        return undefined;
+    }
+
+    function evaluateBinary(left, operator, right) {
+        if (operator === '===') {
+            if (left instanceof Color && right instanceof Color) {
+                return Color.equals(left, right);
+            }
+            return left === right;
+        } else if (operator === '!==') {
+            if (left instanceof Color && right instanceof Color) {
+                return !Color.equals(left, right);
+            }
+            return left !== right;
+        } else if (operator === '+') {
+            if ((typeof left === 'number' && typeof right === 'number') ||
+                (typeof left === 'string' && typeof right === 'string')) {
+                return left + right;
+            }
+        }
+
+        return undefined;
+    }
+
+    function evaluateLogical(left, operator, right) {
+        if (typeof(left) === 'boolean' && typeof(right) === 'boolean') {
+            if (operator === '||') {
+                return (left || right);
+            }
+        }
+        return undefined;
+    }
+
+    function evaluateConditional(test, consequent, alt) {
+        if (typeof(test) === 'boolean') {
+            if (test) {
+                return consequent;
+            } else {
+                return alt;
+            }
+        }
+        return undefined;
+    }
+
+
+    Expression.prototype.evaluate = function(feature) {
+        var type = this._runtimeAST.type;
+
+        if (type === 'Literal') {
             return this._runtimeAST.value;
         }
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -13,6 +13,15 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
+    function MockFeature(value) {
+        this._value = value;
+    }
+
+    MockFeature.prototype.getProperty = function() {
+        return this._value;
+    };
+
+
     it('evaluates literal null', function() {
         var expression = new Expression(new MockStyleEngine(), 'null');
         expect(expression.evaluate(undefined)).toEqual(null);
@@ -45,5 +54,80 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '\'white\'');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+    });
+
+    it('evaluates unary not', function() {
+        var expression = new Expression(new MockStyleEngine(), '!true');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '!!true');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '!5');
+        expect(expression.evaluate(undefined)).toEqual(undefined);
+    });
+
+    it('evaluates unary negative', function() {
+        var expression = new Expression(new MockStyleEngine(), '-1');
+        expect(expression.evaluate(undefined)).toEqual(-1);
+
+        expression = new Expression(new MockStyleEngine(), '--1');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), '-false');
+        expect(expression.evaluate(undefined)).toEqual(undefined);
+    });
+
+    it('evaluates equals operator', function() {
+        var expression = new Expression(new MockStyleEngine(), '1 === 1');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '2 === false');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '\'white\' === \'white\'');
+        expect(expression.evaluate(undefined)).toEqual(true);
+    });
+
+    it('evaluates not equals operator', function() {
+        var expression = new Expression(new MockStyleEngine(), '1 !== 1');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '2 !== 1');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '\'white\' !== \'red\'');
+        expect(expression.evaluate(undefined)).toEqual(true);
+    });
+
+
+    it('evaluates addition operator', function() {
+        var expression = new Expression(new MockStyleEngine(), '1 + 1');
+        expect(expression.evaluate(undefined)).toEqual(2);
+
+        expression = new Expression(new MockStyleEngine(), 'true + false');
+        expect(expression.evaluate(undefined)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '\'he\' + \'llo\'');
+        expect(expression.evaluate(undefined)).toEqual('hello');
+    });
+
+    it('evaluates logical or operator', function() {
+        var expression = new Expression(new MockStyleEngine(), '1 || true');
+        expect(expression.evaluate(undefined)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), 'true || false');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'false || false');
+        expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
+    it('evaluates ternary conditional', function() {
+        var expression = new Expression(new MockStyleEngine(), 'true ? \'yes\' : \'no\'');
+        expect(expression.evaluate(undefined)).toEqual('yes');
+
+        expression = new Expression(new MockStyleEngine(), 'false ? \'yes\' : \'no\'');
+        expect(expression.evaluate(undefined)).toEqual('no');
     });
 });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -13,6 +13,11 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
+    it('evaluates literal null', function() {
+        var expression = new Expression(new MockStyleEngine(), 'null');
+        expect(expression.evaluate(undefined)).toEqual(null);
+    });
+
     it('evaluates literal boolean', function() {
         var expression = new Expression(new MockStyleEngine(), 'true');
         expect(expression.evaluate(undefined)).toEqual(true);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1,8 +1,10 @@
 /*global defineSuite*/
 defineSuite([
-        'Scene/Expression'
+        'Scene/Expression',
+        'Core/Color'
     ], function(
-        Expression) {
+        Expression,
+        Color) {
     'use strict';
 
     function MockStyleEngine() {
@@ -11,8 +13,32 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
-    it('evalutes', function() {
+    it('evaluates literal boolean', function() {
         var expression = new Expression(new MockStyleEngine(), 'true');
         expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'false');
+        expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
+    it('evaluates literal number', function() {
+        var expression = new Expression(new MockStyleEngine(), '1');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), '0');
+        expect(expression.evaluate(undefined)).toEqual(0);
+    });
+
+    it('evaluates literal string', function() {
+        var expression = new Expression(new MockStyleEngine(), '\'hello\'');
+        expect(expression.evaluate(undefined)).toEqual('hello');
+    });
+
+    it('evaluates literal color', function() {
+        var expression = new Expression(new MockStyleEngine(), '\'#ffffff\'');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), '\'white\'');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
     });
 });


### PR DESCRIPTION
Started evaluating expressions if possible when creating the run time AST from the jsep AST.

Added examples of:
 * Unary (`-` and `!`)
 * Binary (`===`, `!=`, and `+`)
 * Logical (`||`)
 * Conditional (`a ? b : c`)

and tests for each.

At this point, we can evaluate any statement with literals and one or more of the above operators

I did not implement any short circuiting yet.
